### PR TITLE
Trying to workaround tigera container path

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,3 +34,6 @@ jobs:
        - name: Run sinker push (dry-run)
          run: ../sinker push --dryrun
          continue-on-error: true
+
+       - name: Run sinker push with magic manifest
+         run: ../sinker push --manifest .tigera.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,4 +36,4 @@ jobs:
          continue-on-error: true
 
        - name: Run sinker push with magic manifest
-         run: ../sinker push --manifest .tigera.yml
+         run: ../sinker push --manifest .tigera.yaml

--- a/.images.yaml
+++ b/.images.yaml
@@ -1,5 +1,21 @@
 target:
   host: ghcr.io
+  repository: stackhpc/calico
+  auth:
+    username: GHCR_USERNAME
+    password: GHCR_PASSWORD
+sources:
+# Calico
+# v3.27.0
+- repository: calico/typha
+  host: docker.io
+  tag: v3.27.0
+- repository: calico/pod2daemon-flexvol
+  host: docker.io
+  tag: v3.27.0
+
+target:
+  host: ghcr.io
   repository: stackhpc
   auth:
     username: GHCR_USERNAME

--- a/.images.yaml
+++ b/.images.yaml
@@ -1,21 +1,5 @@
 target:
   host: ghcr.io
-  repository: stackhpc/calico
-  auth:
-    username: GHCR_USERNAME
-    password: GHCR_PASSWORD
-sources:
-# Calico
-# v3.27.0
-- repository: calico/typha
-  host: docker.io
-  tag: v3.27.0
-- repository: calico/pod2daemon-flexvol
-  host: docker.io
-  tag: v3.27.0
-
-target:
-  host: ghcr.io
   repository: stackhpc
   auth:
     username: GHCR_USERNAME

--- a/.tigera.yaml
+++ b/.tigera.yaml
@@ -21,6 +21,9 @@ sources:
 - repository: calico/node
   host: docker.io
   tag: v3.25.2
+- repository: calico/node-driver-registrar
+  host: docker.io
+  tag: v3.25.2
 - repository: calico/pod2daemon-flexvol
   host: docker.io
   tag: v3.25.2
@@ -43,6 +46,9 @@ sources:
 - repository: calico/node
   host: docker.io
   tag: v3.26.3
+- repository: calico/node-driver-registrar
+  host: docker.io
+  tag: v3.26.3
 - repository: calico/pod2daemon-flexvol
   host: docker.io
   tag: v3.26.3
@@ -63,6 +69,9 @@ sources:
   host: docker.io
   tag: v3.27.0
 - repository: calico/node
+  host: docker.io
+  tag: v3.27.0
+- repository: calico/node-driver-registrar
   host: docker.io
   tag: v3.27.0
 - repository: calico/pod2daemon-flexvol

--- a/.tigera.yaml
+++ b/.tigera.yaml
@@ -1,0 +1,16 @@
+target:
+  host: ghcr.io
+  repository: stackhpc/calico
+  auth:
+    username: GHCR_USERNAME
+    password: GHCR_PASSWORD
+sources:
+# Calico
+# v3.27.0
+- repository: calico/typha
+  host: docker.io
+  tag: v3.27.0
+- repository: calico/pod2daemon-flexvol
+  host: docker.io
+  tag: v3.27.0
+

--- a/.tigera.yaml
+++ b/.tigera.yaml
@@ -5,12 +5,51 @@ target:
     username: GHCR_USERNAME
     password: GHCR_PASSWORD
 sources:
-# Calico
-# v3.27.0
+# v3.25.2
+- repository: calico/cni
+  host: docker.io
+  tag: v3.25.2
+- repository: calico/kube-controllers
+  host: docker.io
+  tag: v3.25.2
+- repository: calico/node
+  host: docker.io
+  tag: v3.25.2
+- repository: calico/pod2daemon-flexvol
+  host: docker.io
+  tag: v3.25.2
 - repository: calico/typha
+  host: docker.io
+  tag: v3.25.2
+# v3.26.3
+- repository: calico/cni
+  host: docker.io
+  tag: v3.26.3
+- repository: calico/kube-controllers
+  host: docker.io
+  tag: v3.26.3
+- repository: calico/node
+  host: docker.io
+  tag: v3.26.3
+- repository: calico/pod2daemon-flexvol
+  host: docker.io
+  tag: v3.26.3
+- repository: calico/typha
+  host: docker.io
+  tag: v3.26.3
+# v3.27.0
+- repository: calico/cni
+  host: docker.io
+  tag: v3.27.0
+- repository: calico/kube-controllers
+  host: docker.io
+  tag: v3.27.0
+- repository: calico/node
   host: docker.io
   tag: v3.27.0
 - repository: calico/pod2daemon-flexvol
   host: docker.io
   tag: v3.27.0
-
+- repository: calico/typha
+  host: docker.io
+  tag: v3.27.0

--- a/.tigera.yaml
+++ b/.tigera.yaml
@@ -6,7 +6,13 @@ target:
     password: GHCR_PASSWORD
 sources:
 # v3.25.2
+- repository: calico/apiserver
+  host: docker.io
+  tag: v3.25.2
 - repository: calico/cni
+  host: docker.io
+  tag: v3.25.2
+- repository: calico/csi
   host: docker.io
   tag: v3.25.2
 - repository: calico/kube-controllers
@@ -22,7 +28,13 @@ sources:
   host: docker.io
   tag: v3.25.2
 # v3.26.3
+- repository: calico/apiserver
+  host: docker.io
+  tag: v3.26.3
 - repository: calico/cni
+  host: docker.io
+  tag: v3.26.3
+- repository: calico/csi
   host: docker.io
   tag: v3.26.3
 - repository: calico/kube-controllers
@@ -38,7 +50,13 @@ sources:
   host: docker.io
   tag: v3.26.3
 # v3.27.0
+- repository: calico/apiserver
+  host: docker.io
+  tag: v3.27.0
 - repository: calico/cni
+  host: docker.io
+  tag: v3.27.0
+- repository: calico/csi
   host: docker.io
   tag: v3.27.0
 - repository: calico/kube-controllers


### PR DESCRIPTION
Tigera expects to be able to pull containers from [REGISTRY/NAMESPACE]/calico/[CONTAINER] path, while GitHub does not support nested paths. Trying to workaround that for now.